### PR TITLE
Add a small sleep delay to the writing thread.

### DIFF
--- a/src/gimbal_interface.cpp
+++ b/src/gimbal_interface.cpp
@@ -1745,7 +1745,8 @@ write_thread(void)
 
 		// signal end
 		writing_status = false;
-	}
+        usleep(10);
+    }
 
 	return;
 


### PR DESCRIPTION
The writing thread is using 100% CPU since it is a free running loop